### PR TITLE
fix: :bug: fix docker build faild

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="mritd <mritd@linux.com>"
 # set up nsswitch.conf for Go's "netgo" implementation
 # - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e "/etc/nsswitch.conf" ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 
 # default timezon
 # override it with `--build-arg TIMEZONE=xxxx`


### PR DESCRIPTION
 alpine 3.16.3 之后， etc/nsswitch.conf 已经加到镜像里了，现在构建会失败。

 参考：

 https://git.alpinelinux.org/aports/commit/?h=v3.16.3&id=348653a9ba0701e8e968b3344e72313a9ef334e4
 
 https://github.com/hyperledger/fabric/pull/3790