### PR TITLE
fixed: basic auth error when set url-prefix.

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,7 +185,7 @@ func main() {
 			})
 
 			fiberRouter := fiberApp.Group(c.String("url-prefix"))
-			routerAuth(c.String("user"), c.String("password"), fiberRouter)
+			routerAuth(c.String("user"), c.String("password"), fiberRouter, c.String("url-prefix"))
 			routerSetup(fiberRouter)
 
 			if serverless := c.Bool("serverless"); serverless {

--- a/route_auth.go
+++ b/route_auth.go
@@ -1,29 +1,34 @@
 package main
 
 import (
+	"path"
+	"strings"
+
 	"github.com/gofiber/fiber/v2"
 	fiberbasicauth "github.com/gofiber/fiber/v2/middleware/basicauth"
 	"github.com/mritd/logger"
-	"strings"
 )
 
-func routerAuth(user, passwd string, router fiber.Router) {
-	if user != "" && passwd != "" {
-		logger.Info("Bark Server Has Basic Auth Enabled.")
-		basicAuth := fiberbasicauth.New(fiberbasicauth.Config{
-			Users: map[string]string{user: passwd},
-			Realm: "Coffee Time",
-			Unauthorized: func(c *fiber.Ctx) error {
-				authFreeRouters := []string{"/ping", "/register", "/healthz"}
-				for _, item := range authFreeRouters {
-					if strings.HasPrefix(c.Path(), item) {
-						return c.Next()
-					}
-				}
-				return c.Status(418).SendString("I'm a teapot")
-			},
-		})
-
-		router.Use("/+", basicAuth)
+func routerAuth(user, passwd string, router fiber.Router, urlPrefix string) {
+	if user == "" && passwd == "" {
+		logger.Info("Bark Server Has No Basic Auth.")
+		return
 	}
+
+	logger.Info("Bark Server Has Basic Auth Enabled.")
+	authFreeRouters := []string{"/ping", "/register", "/healthz"}
+	basicAuth := fiberbasicauth.New(fiberbasicauth.Config{
+		Users: map[string]string{user: passwd},
+		Realm: "Coffee Time",
+		Unauthorized: func(c *fiber.Ctx) error {
+			for _, item := range authFreeRouters {
+				if strings.HasPrefix(c.Path(), path.Join(urlPrefix, item)) {
+					return c.Next()
+				}
+			}
+			return c.Status(418).SendString("I'm a teapot")
+		},
+	})
+
+	router.Use("/+", basicAuth)
 }


### PR DESCRIPTION
When `url-prefix` is set, "/ping", "/register", "/healthz" that do not require authentication are also authenticated.