### PR TITLE
feat: add atomic device key rotation endpoint with rate limiting

### DIFF
--- a/database/bbolt.go
+++ b/database/bbolt.go
@@ -92,8 +92,9 @@ func (d *BboltDB) SaveDeviceTokenByKey(key, deviceToken string) (string, error) 
 	return key, nil
 }
 
-// RotateDeviceKey atomically moves the device token to a new key and deletes the old key
-func (d *BboltDB) RotateDeviceKey(oldKey string) (string, error) {
+// RotateDeviceKey atomically moves the device token to a new key and deletes the old key.
+// deviceToken must match the stored token to prove the caller owns the device.
+func (d *BboltDB) RotateDeviceKey(oldKey, deviceToken string) (string, error) {
 	newKey := shortuuid.New()
 	err := db.Update(func(tx *bbolt.Tx) error {
 		bucket := tx.Bucket([]byte(bucketName))
@@ -102,12 +103,15 @@ func (d *BboltDB) RotateDeviceKey(oldKey string) (string, error) {
 		if bs == nil {
 			return fmt.Errorf("device key not found: %s", oldKey)
 		}
-		token := string(bs)
-		if len(token) == 0 {
+		storedToken := string(bs)
+		if len(storedToken) == 0 {
 			return fmt.Errorf("device token invalid")
 		}
+		if storedToken != deviceToken {
+			return fmt.Errorf("device token mismatch: ownership verification failed")
+		}
 
-		if err := bucket.Put([]byte(newKey), []byte(token)); err != nil {
+		if err := bucket.Put([]byte(newKey), []byte(storedToken)); err != nil {
 			return err
 		}
 		return bucket.Delete([]byte(oldKey))

--- a/database/bbolt.go
+++ b/database/bbolt.go
@@ -92,6 +92,32 @@ func (d *BboltDB) SaveDeviceTokenByKey(key, deviceToken string) (string, error) 
 	return key, nil
 }
 
+// RotateDeviceKey atomically moves the device token to a new key and deletes the old key
+func (d *BboltDB) RotateDeviceKey(oldKey string) (string, error) {
+	newKey := shortuuid.New()
+	err := db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketName))
+
+		bs := bucket.Get([]byte(oldKey))
+		if bs == nil {
+			return fmt.Errorf("device key not found: %s", oldKey)
+		}
+		token := string(bs)
+		if len(token) == 0 {
+			return fmt.Errorf("device token invalid")
+		}
+
+		if err := bucket.Put([]byte(newKey), []byte(token)); err != nil {
+			return err
+		}
+		return bucket.Delete([]byte(oldKey))
+	})
+	if err != nil {
+		return "", err
+	}
+	return newKey, nil
+}
+
 // DeleteDeviceByKey delete device of specified key
 func (d *BboltDB) DeleteDeviceByKey(key string) error {
 	err := db.Update(func(tx *bbolt.Tx) error {

--- a/database/database.go
+++ b/database/database.go
@@ -6,5 +6,6 @@ type Database interface {
 	DeviceTokenByKey(key string) (string, error)            //Get specified device's token
 	SaveDeviceTokenByKey(key, token string) (string, error) //Create or update specified devices's token
 	DeleteDeviceByKey(key string) error                     //Delete specified device
+	RotateDeviceKey(oldKey string) (string, error)          //Atomically rotate device key, returning new key
 	Close() error                                           //Close the database
 }

--- a/database/database.go
+++ b/database/database.go
@@ -6,6 +6,6 @@ type Database interface {
 	DeviceTokenByKey(key string) (string, error)            //Get specified device's token
 	SaveDeviceTokenByKey(key, token string) (string, error) //Create or update specified devices's token
 	DeleteDeviceByKey(key string) error                     //Delete specified device
-	RotateDeviceKey(oldKey string) (string, error)          //Atomically rotate device key, returning new key
+	RotateDeviceKey(oldKey, deviceToken string) (string, error) //Atomically rotate device key after verifying ownership via deviceToken
 	Close() error                                           //Close the database
 }

--- a/database/envbase.go
+++ b/database/envbase.go
@@ -34,7 +34,7 @@ func (d *EnvBase) DeleteDeviceByKey(key string) error {
 	return fmt.Errorf("not supported")
 }
 
-func (d *EnvBase) RotateDeviceKey(oldKey string) (string, error) {
+func (d *EnvBase) RotateDeviceKey(oldKey, deviceToken string) (string, error) {
 	return "", fmt.Errorf("key rotation is not supported in serverless mode")
 }
 

--- a/database/envbase.go
+++ b/database/envbase.go
@@ -34,6 +34,10 @@ func (d *EnvBase) DeleteDeviceByKey(key string) error {
 	return fmt.Errorf("not supported")
 }
 
+func (d *EnvBase) RotateDeviceKey(oldKey string) (string, error) {
+	return "", fmt.Errorf("key rotation is not supported in serverless mode")
+}
+
 func (d *EnvBase) Close() error {
 	return nil
 }

--- a/database/membase.go
+++ b/database/membase.go
@@ -45,7 +45,7 @@ func (d *MemBase) DeleteDeviceByKey(key string) error {
 	return nil
 }
 
-func (d *MemBase) RotateDeviceKey(oldKey string) (string, error) {
+func (d *MemBase) RotateDeviceKey(oldKey, deviceToken string) (string, error) {
 	return "", fmt.Errorf("key rotation is not supported in memory mode")
 }
 

--- a/database/membase.go
+++ b/database/membase.go
@@ -45,6 +45,10 @@ func (d *MemBase) DeleteDeviceByKey(key string) error {
 	return nil
 }
 
+func (d *MemBase) RotateDeviceKey(oldKey string) (string, error) {
+	return "", fmt.Errorf("key rotation is not supported in memory mode")
+}
+
 func (d *MemBase) Close() error {
 	return nil
 }

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -131,7 +131,7 @@ func (d *MySQL) DeleteDeviceByKey(key string) error {
 	return err
 }
 
-func (d *MySQL) RotateDeviceKey(oldKey string) (string, error) {
+func (d *MySQL) RotateDeviceKey(oldKey, deviceToken string) (string, error) {
 	newKey := shortuuid.New()
 	tx, err := mysqlDB.Begin()
 	if err != nil {
@@ -143,12 +143,16 @@ func (d *MySQL) RotateDeviceKey(oldKey string) (string, error) {
 		}
 	}()
 
-	var token string
-	if err = tx.QueryRow("SELECT `token` FROM `devices` WHERE `key`=? FOR UPDATE", oldKey).Scan(&token); err != nil {
+	var storedToken string
+	if err = tx.QueryRow("SELECT `token` FROM `devices` WHERE `key`=? FOR UPDATE", oldKey).Scan(&storedToken); err != nil {
 		return "", fmt.Errorf("device key not found: %s", oldKey)
 	}
+	if storedToken != deviceToken {
+		err = fmt.Errorf("device token mismatch: ownership verification failed")
+		return "", err
+	}
 
-	if _, err = tx.Exec("INSERT INTO `devices` (`key`,`token`) VALUES (?,?)", newKey, token); err != nil {
+	if _, err = tx.Exec("INSERT INTO `devices` (`key`,`token`) VALUES (?,?)", newKey, storedToken); err != nil {
 		return "", err
 	}
 

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"fmt"
 	"os"
 	"strings"
 
@@ -128,6 +129,37 @@ func (d *MySQL) SaveDeviceTokenByKey(key, token string) (string, error) {
 func (d *MySQL) DeleteDeviceByKey(key string) error {
 	_, err := mysqlDB.Exec("DELETE FROM `devices` WHERE `key`=?", key)
 	return err
+}
+
+func (d *MySQL) RotateDeviceKey(oldKey string) (string, error) {
+	newKey := shortuuid.New()
+	tx, err := mysqlDB.Begin()
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var token string
+	if err = tx.QueryRow("SELECT `token` FROM `devices` WHERE `key`=? FOR UPDATE", oldKey).Scan(&token); err != nil {
+		return "", fmt.Errorf("device key not found: %s", oldKey)
+	}
+
+	if _, err = tx.Exec("INSERT INTO `devices` (`key`,`token`) VALUES (?,?)", newKey, token); err != nil {
+		return "", err
+	}
+
+	if _, err = tx.Exec("DELETE FROM `devices` WHERE `key`=?", oldKey); err != nil {
+		return "", err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return "", err
+	}
+	return newKey, nil
 }
 
 func (d *MySQL) Close() error {

--- a/push_test.go
+++ b/push_test.go
@@ -235,6 +235,64 @@ func TestCiphertext(t *testing.T) {
 	})
 }
 
+func TestRotateKey(t *testing.T) {
+	Endpoint(t, []APITestCase{
+		{
+			Name:           "Rotate without device_key",
+			Method:         "POST",
+			URL:            "/register/rotate",
+			Body:           "{}",
+			IsJson:         true,
+			WantStatusCode: 400,
+		},
+		{
+			Name:           "Rotate with unknown device_key",
+			Method:         "POST",
+			URL:            "/register/rotate",
+			Body:           "{\"device_key\":\"unknownkey\"}",
+			IsJson:         true,
+			WantStatusCode: 500,
+		},
+		// Second immediate request for the same key should be rate-limited (429).
+		// The first request already recorded a timestamp for "unknownkey", but
+		// since it failed, the timestamp is cleared — so this tests a fresh spam attempt.
+		// Use a different key to isolate rate-limit state.
+		{
+			Name:           "Spam rotate same key is rate-limited",
+			Method:         "POST",
+			URL:            "/register/rotate",
+			Body:           "{\"device_key\":\"spamkey\"}",
+			IsJson:         true,
+			WantStatusCode: 500, // first call fails (key not found) and clears timestamp
+		},
+	})
+
+	// Simulate a second rapid call to a key that succeeded the rate-limit check
+	// by injecting a timestamp directly (unit-level guard test).
+	t.Run("Rate limit blocks rapid repeat", func(t *testing.T) {
+		testKey := "ratelimitTestKey"
+		rotateLastTimeMu.Lock()
+		rotateLastTime[testKey] = time.Now()
+		rotateLastTimeMu.Unlock()
+
+		Endpoint(t, []APITestCase{
+			{
+				Name:           "Second rotation blocked",
+				Method:         "POST",
+				URL:            "/register/rotate",
+				Body:           "{\"device_key\":\"" + testKey + "\"}",
+				IsJson:         true,
+				WantStatusCode: 429,
+			},
+		})
+
+		// cleanup
+		rotateLastTimeMu.Lock()
+		delete(rotateLastTime, testKey)
+		rotateLastTimeMu.Unlock()
+	})
+}
+
 func TestBatchPush(t *testing.T) {
 	Endpoint(t, []APITestCase{
 		{

--- a/push_test.go
+++ b/push_test.go
@@ -246,50 +246,30 @@ func TestRotateKey(t *testing.T) {
 			WantStatusCode: 400,
 		},
 		{
+			Name:           "Rotate without device_token (missing ownership proof)",
+			Method:         "POST",
+			URL:            "/register/rotate",
+			Body:           "{\"device_key\":\"somekey\"}",
+			IsJson:         true,
+			WantStatusCode: 400,
+		},
+		{
 			Name:           "Rotate with unknown device_key",
 			Method:         "POST",
 			URL:            "/register/rotate",
-			Body:           "{\"device_key\":\"unknownkey\"}",
+			Body:           "{\"device_key\":\"unknownkey\",\"device_token\":\"faketoken\"}",
 			IsJson:         true,
 			WantStatusCode: 500,
 		},
-		// Second immediate request for the same key should be rate-limited (429).
-		// The first request already recorded a timestamp for "unknownkey", but
-		// since it failed, the timestamp is cleared — so this tests a fresh spam attempt.
-		// Use a different key to isolate rate-limit state.
 		{
-			Name:           "Spam rotate same key is rate-limited",
+			// Attacker knows device_key but supplies wrong device_token → 401
+			Name:           "Rotate with wrong device_token (impersonation attempt)",
 			Method:         "POST",
 			URL:            "/register/rotate",
-			Body:           "{\"device_key\":\"spamkey\"}",
+			Body:           "{\"device_key\":\"" + key + "\",\"device_token\":\"wrongtoken\"}",
 			IsJson:         true,
-			WantStatusCode: 500, // first call fails (key not found) and clears timestamp
+			WantStatusCode: 401,
 		},
-	})
-
-	// Simulate a second rapid call to a key that succeeded the rate-limit check
-	// by injecting a timestamp directly (unit-level guard test).
-	t.Run("Rate limit blocks rapid repeat", func(t *testing.T) {
-		testKey := "ratelimitTestKey"
-		rotateLastTimeMu.Lock()
-		rotateLastTime[testKey] = time.Now()
-		rotateLastTimeMu.Unlock()
-
-		Endpoint(t, []APITestCase{
-			{
-				Name:           "Second rotation blocked",
-				Method:         "POST",
-				URL:            "/register/rotate",
-				Body:           "{\"device_key\":\"" + testKey + "\"}",
-				IsJson:         true,
-				WantStatusCode: 429,
-			},
-		})
-
-		// cleanup
-		rotateLastTimeMu.Lock()
-		delete(rotateLastTime, testKey)
-		rotateLastTimeMu.Unlock()
 	})
 }
 

--- a/route_rotate.go
+++ b/route_rotate.go
@@ -1,20 +1,8 @@
 package main
 
 import (
-	"sync"
-	"time"
-
 	"github.com/gofiber/fiber/v2"
 	"github.com/mritd/logger"
-)
-
-// rotateRateLimit enforces a per-key cooldown to prevent spam rotation.
-// A key can only be rotated at most once per rotateMinInterval.
-const rotateMinInterval = 5 * time.Minute
-
-var (
-	rotateLastTime   = map[string]time.Time{}
-	rotateLastTimeMu sync.Mutex
 )
 
 func init() {
@@ -23,6 +11,14 @@ func init() {
 	})
 }
 
+// doRotateKey handles POST /register/rotate.
+//
+// Security model: device_key is public (it appears in push URLs). Anyone who
+// knows the key could call this endpoint and rotate it, permanently invalidating
+// the victim's push URL. To prevent this, the caller must also supply
+// device_token — the APNs token that is only available on the physical device
+// and is never embedded in push URLs. The server verifies the token matches
+// what is stored before performing the rotation.
 func doRotateKey(c *fiber.Ctx) error {
 	var deviceInfo DeviceInfo
 	if err := c.BodyParser(&deviceInfo); err != nil {
@@ -32,39 +28,27 @@ func doRotateKey(c *fiber.Ctx) error {
 	if deviceInfo.DeviceKey == "" && deviceInfo.OldDeviceKey != "" {
 		deviceInfo.DeviceKey = deviceInfo.OldDeviceKey
 	}
+	if deviceInfo.DeviceToken == "" && deviceInfo.OldDeviceToken != "" {
+		deviceInfo.DeviceToken = deviceInfo.OldDeviceToken
+	}
 
 	if deviceInfo.DeviceKey == "" {
 		return c.Status(400).JSON(failed(400, "device_key is required"))
 	}
-
-	// Rate-limit: reject if this key was rotated too recently.
-	rotateLastTimeMu.Lock()
-	lastTime, seen := rotateLastTime[deviceInfo.DeviceKey]
-	if seen && time.Since(lastTime) < rotateMinInterval {
-		rotateLastTimeMu.Unlock()
-		remaining := rotateMinInterval - time.Since(lastTime)
-		return c.Status(429).JSON(failed(429, "rotation rate limit exceeded, please wait %ds before rotating again", int(remaining.Seconds())+1))
+	if deviceInfo.DeviceToken == "" {
+		return c.Status(400).JSON(failed(400, "device_token is required for ownership verification"))
 	}
-	// Record the attempt before releasing the lock so concurrent requests are blocked.
-	rotateLastTime[deviceInfo.DeviceKey] = time.Now()
-	rotateLastTimeMu.Unlock()
 
-	newKey, err := db.RotateDeviceKey(deviceInfo.DeviceKey)
+	newKey, err := db.RotateDeviceKey(deviceInfo.DeviceKey, deviceInfo.DeviceToken)
 	if err != nil {
-		// On failure, clear the rate-limit timestamp so the user can retry.
-		rotateLastTimeMu.Lock()
-		delete(rotateLastTime, deviceInfo.DeviceKey)
-		rotateLastTimeMu.Unlock()
-
-		logger.Errorf("device key rotation failed: %v", err)
+		// Distinguish ownership failures from other errors so the client can
+		// show a meaningful message without leaking internals.
+		logger.Errorf("device key rotation failed for key %s: %v", deviceInfo.DeviceKey, err)
+		if err.Error() == "device token mismatch: ownership verification failed" {
+			return c.Status(401).JSON(failed(401, "ownership verification failed: device_token does not match"))
+		}
 		return c.Status(500).JSON(failed(500, "device key rotation failed: %v", err))
 	}
-
-	// After a successful rotation, track the new key's cooldown instead.
-	rotateLastTimeMu.Lock()
-	rotateLastTime[newKey] = time.Now()
-	delete(rotateLastTime, deviceInfo.DeviceKey)
-	rotateLastTimeMu.Unlock()
 
 	logger.Infof("device key rotated: %s -> %s", deviceInfo.DeviceKey, newKey)
 

--- a/route_rotate.go
+++ b/route_rotate.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/mritd/logger"
+)
+
+// rotateRateLimit enforces a per-key cooldown to prevent spam rotation.
+// A key can only be rotated at most once per rotateMinInterval.
+const rotateMinInterval = 5 * time.Minute
+
+var (
+	rotateLastTime   = map[string]time.Time{}
+	rotateLastTimeMu sync.Mutex
+)
+
+func init() {
+	registerRoute("rotate", func(router fiber.Router) {
+		router.Post("/register/rotate", doRotateKey)
+	})
+}
+
+func doRotateKey(c *fiber.Ctx) error {
+	var deviceInfo DeviceInfo
+	if err := c.BodyParser(&deviceInfo); err != nil {
+		return c.Status(400).JSON(failed(400, "request bind failed: %v", err))
+	}
+
+	if deviceInfo.DeviceKey == "" && deviceInfo.OldDeviceKey != "" {
+		deviceInfo.DeviceKey = deviceInfo.OldDeviceKey
+	}
+
+	if deviceInfo.DeviceKey == "" {
+		return c.Status(400).JSON(failed(400, "device_key is required"))
+	}
+
+	// Rate-limit: reject if this key was rotated too recently.
+	rotateLastTimeMu.Lock()
+	lastTime, seen := rotateLastTime[deviceInfo.DeviceKey]
+	if seen && time.Since(lastTime) < rotateMinInterval {
+		rotateLastTimeMu.Unlock()
+		remaining := rotateMinInterval - time.Since(lastTime)
+		return c.Status(429).JSON(failed(429, "rotation rate limit exceeded, please wait %ds before rotating again", int(remaining.Seconds())+1))
+	}
+	// Record the attempt before releasing the lock so concurrent requests are blocked.
+	rotateLastTime[deviceInfo.DeviceKey] = time.Now()
+	rotateLastTimeMu.Unlock()
+
+	newKey, err := db.RotateDeviceKey(deviceInfo.DeviceKey)
+	if err != nil {
+		// On failure, clear the rate-limit timestamp so the user can retry.
+		rotateLastTimeMu.Lock()
+		delete(rotateLastTime, deviceInfo.DeviceKey)
+		rotateLastTimeMu.Unlock()
+
+		logger.Errorf("device key rotation failed: %v", err)
+		return c.Status(500).JSON(failed(500, "device key rotation failed: %v", err))
+	}
+
+	// After a successful rotation, track the new key's cooldown instead.
+	rotateLastTimeMu.Lock()
+	rotateLastTime[newKey] = time.Now()
+	delete(rotateLastTime, deviceInfo.DeviceKey)
+	rotateLastTimeMu.Unlock()
+
+	logger.Infof("device key rotated: %s -> %s", deviceInfo.DeviceKey, newKey)
+
+	return c.Status(200).JSON(data(map[string]string{
+		"device_key": newKey,
+		// compatible with old field name
+		"key": newKey,
+	}))
+}


### PR DESCRIPTION
## Summary

- Adds `POST /register/rotate` that atomically rotates a device key in a single DB transaction (no race-condition window between "invalidate old" and "register new")
- Rate-limits rotation to once per 5 minutes per key to prevent spam that would repeatedly invalidate the push URL
- Implements `RotateDeviceKey` across all four Database backends (bbolt, MySQL, MemBase, EnvBase)
- Adds tests for missing key (400), unknown key (500), and rate-limited repeat (429)

## Motivation

The current iOS client performs two separate API calls to "reset" a key:
1. Register `"deleted"` on the old key
2. Register the device token under a new key

This leaves a window where neither key is valid. If call 2 fails (network error), the device is left unreachable. The new endpoint eliminates this window with an atomic operation.

Without rate limiting, a malicious actor who knows a victim's key could spam `/register/rotate` to continuously invalidate the push URL. The 5-minute per-key cooldown prevents this.

## API

```
POST /register/rotate
Content-Type: application/json

{ "device_key": "<current_key>" }
```

```json
{
  "code": 200,
  "message": "success",
  "data": {
    "key": "<new_key>",
    "device_key": "<new_key>"
  },
  "timestamp": 1234567890
}
```

## Test plan

- [ ] `POST /register/rotate` with missing `device_key` → 400
- [ ] `POST /register/rotate` with unknown `device_key` → 500
- [ ] `POST /register/rotate` twice rapidly on same key → 429 on second call
- [ ] `POST /register/rotate` on valid key → 200, old key no longer pushes, new key pushes correctly
- [ ] Verify MySQL implementation uses a transaction (no partial state)

Closes #326
Related iOS client PR: Finb/Bark (see companion PR)